### PR TITLE
Migrate from `argparse` to `typer`. And misc improvements

### DIFF
--- a/refman/_bibpain.py
+++ b/refman/_bibpain.py
@@ -12,9 +12,23 @@ from utf8tobibtex import utf8_to_bibtex
 from arxiv2bib import ATOM, arxiv2bib
 
 ARXIV_CATEGORIES = [
-    "astro-ph", "cond-mat", "gr-qc", "hep-ex", "hep-lat", "hep-ph", "hep-th",
-    "math-ph", "nlin", "nucl-ex", "nucl-th", "physics", "quant-ph", "math",
-    "q-bio", "q-fin", "stat"
+    "astro-ph",
+    "cond-mat",
+    "gr-qc",
+    "hep-ex",
+    "hep-lat",
+    "hep-ph",
+    "hep-th",
+    "math-ph",
+    "nlin",
+    "nucl-ex",
+    "nucl-th",
+    "physics",
+    "quant-ph",
+    "math",
+    "q-bio",
+    "q-fin",
+    "stat",
 ]
 
 
@@ -26,16 +40,16 @@ def check_categories(text):
 
 
 def doi2bib(doi):
-    url = 'https://doi.org/' + urllib.request.quote(doi)
+    url = "https://doi.org/" + urllib.request.quote(doi)
     header = {
-        'Accept': 'application/x-bibtex',
+        "Accept": "application/x-bibtex",
     }
     response = requests.get(url, headers=header)
     return response.text
 
 
 def get_bibid_for_arxiv(reference):
-    xml_list = reference.xml.findall(ATOM + 'author/' + ATOM + 'name')
+    xml_list = reference.xml.findall(ATOM + "author/" + ATOM + "name")
     first_author = xml_list[0].text.split()[-1].lower()
     titleword = reference.title.split()[0].lower()
     return first_author + reference.year + titleword
@@ -44,37 +58,37 @@ def get_bibid_for_arxiv(reference):
 def normalize(text_):
     text = utf8_to_bibtex(text_)
     text = text.replace("{{\\textbackslash}hspace{0.167em}}", "")
-    text = text.replace('\t', '  ')
-    text = re.sub('"\n', '}\n', text)
-    text = re.sub('=\w+"', '= {', text)
+    text = text.replace("\t", "  ")
+    text = re.sub('"\n', "}\n", text)
+    text = re.sub('=\w+"', "= {", text)
     year = None
     year_line = re.findall("year[^\n]*", text)
     if year_line != []:
         year_string = year_line[0]
-        if '{' not in year_string:
+        if "{" not in year_string:
             year = year_string[-5:-1]
-            text = text.replace(year_string,
-                                year_string.replace(year, "{" + year + "}"))
+            text = text.replace(
+                year_string, year_string.replace(year, "{" + year + "}")
+            )
         else:
             year = year_string[-6:-2]
     first_author = None
     author_line = re.findall("author[^\n]*", text)
     if author_line != []:
-        author_list = author_line[0][author_line[0].find("{") + 1:-2]
+        author_list = author_line[0][author_line[0].find("{") + 1 : -2]
         authors = author_list.split(" and ")
         if "," in authors[0]:
-            first_author = authors[0][:authors[0].find(",")]
+            first_author = authors[0][: authors[0].find(",")]
         else:
-            first_author = authors[0][authors[0].rindex(" ") + 1:]
+            first_author = authors[0][authors[0].rindex(" ") + 1 :]
         first_author = first_author.lower()
     first_title_word = None
     title_line = re.findall("title[^\n]*", text)
     if title_line != []:
         first_title_word = re.findall("{[A-Za-z]*", title_line[0])[0][1:]
         first_title_word = first_title_word.lower()
-    if first_title_word is not None and first_author is not None and \
-            year is not None:
-        original_id = text[text.find('{') + 1:text.find(',')]
+    if first_title_word is not None and first_author is not None and year is not None:
+        original_id = text[text.find("{") + 1 : text.find(",")]
         new_id = first_author + year + first_title_word
         text = text.replace(original_id, new_id)
     if "timestamp" not in text:
@@ -96,22 +110,26 @@ def find_file(name):
     for root, dirs, files in os.walk(base_dir):
         if name in files:
             filename = os.path.join(root, name)
-            return "	file = {" + filename[len(base_dir) + 1:] + "},"
+            return "	file = {" + filename[len(base_dir) + 1 :] + "},"
 
 
 def postprocess_arxiv(entry):
     id_ = entry.id
     url = entry.url.replace("http", "https")
-    if id_[-2] == 'v':
+    if id_[-2] == "v":
         id_ = id_[:-2]
         url = url[:-2]
     if len(entry.doi) == 0:
         lines = ["@article{" + get_bibid_for_arxiv(entry)]
-        for k, v in [("  author", " and ".join(entry.authors)), ("  title",
-                                                                 entry.title),
-                     ("  archiveprefix",
-                      "arXiv"), ("  eprint", id_), ("  year", entry.year),
-                     ("  note", entry.note), ("  abstract", entry.summary)]:
+        for k, v in [
+            ("  author", " and ".join(entry.authors)),
+            ("  title", entry.title),
+            ("  archiveprefix", "arXiv"),
+            ("  eprint", id_),
+            ("  year", entry.year),
+            ("  note", entry.note),
+            ("  abstract", entry.summary),
+        ]:
             if len(v):
                 lines.append("%-13s = {%s}" % (k, v))
         return ("," + os.linesep).join(lines) + os.linesep + "}"
@@ -119,8 +137,7 @@ def postprocess_arxiv(entry):
         result = doi2bib(entry.doi)[:-2]
         result += "," + os.linesep + "  archiveprefix = {arXiv}"
         result += "," + os.linesep + "%-13s = {%s}" % ("  eprint", id_)
-        result += "," + os.linesep + "%-13s = {%s}" % ("  abstract",
-                                                       entry.summary)
+        result += "," + os.linesep + "%-13s = {%s}" % ("  abstract", entry.summary)
         return result + os.linesep + "}"
 
 
@@ -131,15 +148,15 @@ def process_id(id_):
     id_lower = processed_id.lower()
     category = check_categories(processed_id)
     if "iv:" in id_lower:
-        processed_id = id_lower[id_lower.index(":") + 1:]
+        processed_id = id_lower[id_lower.index(":") + 1 :]
     elif "iv.org" in id_lower:
         if category is not None:
-            processed_id = id_lower[id_lower.index(category):]
+            processed_id = id_lower[id_lower.index(category) :]
         else:
-            processed_id = id_lower[id_lower.rindex("/") + 1:]
+            processed_id = id_lower[id_lower.rindex("/") + 1 :]
     elif "doi.org" in id_lower:
-        processed_id = processed_id[id_lower.index("doi.org/") + 8:]
-    regexp = re.compile(r'[a-zA-Z]+[0-9]+[a-zA-Z]+')
+        processed_id = processed_id[id_lower.index("doi.org/") + 8 :]
+    regexp = re.compile(r"[a-zA-Z]+[0-9]+[a-zA-Z]+")
     if regexp.search(processed_id):
         return find_file(processed_id + ".pdf")
     elif category is not None and processed_id.startswith(category):

--- a/refman/_utils.py
+++ b/refman/_utils.py
@@ -28,28 +28,29 @@ def is_valid_url(url: str):
 def is_valid_doi(doi: str):
     return bool(re.match(doi_regex, doi))
 
+
 def fix_arxiv2bib_fmt(ref: Reference):
     """I don't like the bibtex format from either the arxiv API, or from
     arxiv2bib, so this function uses the data from arxiv2bib to properly
     format the bibtex reference the way I like it."""
     # My preferred format for ID is: 'FirstSurname_Year'
     id_fmt = f"{ref.authors[0].split(' ')[1]}_{ref.year}"
-    url = ref.url[:ref.url.rfind('v')] if ref.id != ref.bare_id else ref.url
-    
+    url = ref.url[: ref.url.rfind("v")] if ref.id != ref.bare_id else ref.url
+
     lines = ["@article{" + id_fmt]
     for k, v in [
-            ("Author", " and ".join(ref.authors)),
-            ("Title", ref.title),
-            ("Eprint", ref.bare_id),  # The trailing 'vX' is just an annoyance
-            ("DOI", ref.doi),
-            ("ArchivePrefix", "arXiv"),
-            ("PrimaryClass", ref.category),
-            ("Abstract", ref.summary),
-            ("Year", ref.year),
-            ("Month", ref.month),
-            ("Note", ref.note),
-            ("Url", url),
-            ("File", id_fmt + ".pdf"),
+        ("Author", " and ".join(ref.authors)),
+        ("Title", ref.title),
+        ("Eprint", ref.bare_id),  # The trailing 'vX' is just an annoyance
+        ("DOI", ref.doi),
+        ("ArchivePrefix", "arXiv"),
+        ("PrimaryClass", ref.category),
+        ("Abstract", ref.summary),
+        ("Year", ref.year),
+        ("Month", ref.month),
+        ("Note", ref.note),
+        ("Url", url),
+        ("File", id_fmt + ".pdf"),
     ]:
         if len(v):
             lines.append("%-13s = {%s}" % (k, v))

--- a/refman/refman.py
+++ b/refman/refman.py
@@ -43,7 +43,7 @@ SH = SciHub()
 APP = typer.Typer(help="RefMan - A Simple python-based reference manager.")
 
 
-def update_status(msg: str, level_attr: str = 'info'):
+def update_status(msg: str, level_attr: str = "info"):
     global STATUS_HANDLER
     if not isinstance(STATUS_HANDLER, tqdm):
         # LOGGER.__getattr__(level_attr)
@@ -57,6 +57,7 @@ def progress_with_status(it: Iterable):
     ncols = str(min(len(it), 20))
     barfmt = "{l_bar}{bar:" + ncols + "}{r_bar}{bar:-" + ncols + "b}"
     return (STATUS_HANDLER := tqdm(it, bar_format=barfmt))
+
 
 def reset_progress_status_handler():
     global STATUS_HANDLER
@@ -213,7 +214,7 @@ class Paper:
                 with open(pdf_path, "r") as f:
                     LOGGER.info(f"{bibtex_key}: Got PDF from DISK.")
                     pdf_data = f.read()
-        
+
         return pdf_data
 
     @classmethod
@@ -300,7 +301,7 @@ class RefMan:
 
     def remove_from_db(self, column: str, value: str):
         self.db = self.db[self.db[column] != value]
-        
+
     def add_using_arxiv(self, arxiv: str, key: str = None):
         if arxiv is not None and arxiv not in list(self.db.get("eprint", list())):
             paper = Paper.new_paper_from_arxiv(arxiv, key)
@@ -310,12 +311,8 @@ class RefMan:
         return paper.meta.get("ID", "")
 
     def add_using_doi(self, doi: str, pdf: str):
-        if (
-                doi is not None and
-                doi.lower() not in map(
-                    lambda x: x.lower(),
-                    self.db.get("doi", list())
-                )
+        if doi is not None and doi.lower() not in map(
+            lambda x: x.lower(), self.db.get("doi", list())
         ):
             paper = Paper.new_paper_from_doi(doi, pdf)
             self.append_to_db(paper)
@@ -323,16 +320,9 @@ class RefMan:
         self._update_db()
         return paper.meta.get("ID", "")
 
-    def add_using_bibtex(
-            self,
-            bibtex_str: str,
-            pdf_path: str,
-            key: str = None
-    ):
+    def add_using_bibtex(self, bibtex_str: str, pdf_path: str, key: str = None):
         paper = Paper.new_paper_from_bibtex(
-            bibtex_str=bibtex_str,
-            pdf_path=pdf_path,
-            key=key
+            bibtex_str=bibtex_str, pdf_path=pdf_path, key=key
         )
         self.append_to_db(paper)
         self._update_db()
@@ -341,15 +331,17 @@ class RefMan:
     def rekey(self, key: str, new_key: str):
         paper_path_li = list(REFMAN_DIR.glob(key + "*"))
         if len(paper_path_li) > 1:
-            raise ValueError(f"Multiple papers matching wildcard: {key + '*'}.\n{paper_path_li=}.")
+            raise ValueError(
+                f"Multiple papers matching wildcard: {key + '*'}.\n{paper_path_li=}."
+            )
         if len(paper_path_li) == 0:
-            raise FileNotFoundError(f"No papers matching wildcard: {key + '*'}. Exiting.")
+            raise FileNotFoundError(
+                f"No papers matching wildcard: {key + '*'}. Exiting."
+            )
         paper_path = paper_path_li[0]
         old_paper = Paper.parse_from_disk(paper_path)
         new_paper = Paper.new_paper_from_bibtex(
-            bibtex_str=old_paper.bibtex,
-            pdf_path=old_paper.pdf_path,
-            key=new_key
+            bibtex_str=old_paper.bibtex, pdf_path=old_paper.pdf_path, key=new_key
         )
         # Remove the old paper
         self.remove_paper(key)
@@ -361,11 +353,15 @@ class RefMan:
             LOGGER.info(f"Couldn't find any paper at: {paper_path}. Trying wildcard...")
             paper_path_li = list(REFMAN_DIR.glob(key + "*"))
             if len(paper_path_li) > 1:
-                raise ValueError(f"Multiple papers matching wildcard: {key + '*'}.\n{paper_path_li=}.")
+                raise ValueError(
+                    f"Multiple papers matching wildcard: {key + '*'}.\n{paper_path_li=}."
+                )
             if len(paper_path_li) == 0:
-                raise FileNotFoundError(f"No papers matching wildcard: {key + '*'}. Exiting.")
+                raise FileNotFoundError(
+                    f"No papers matching wildcard: {key + '*'}. Exiting."
+                )
             paper_path = paper_path_li[0]
-                
+
         LOGGER.info(f"Found paper: {paper_path}: Removing it and updating database.")
         shutil.rmtree(paper_path)
         self.remove_from_db(column="bibtex_path", value=str(paper_path / BIBTEX_NAME))

--- a/refman/refman.py
+++ b/refman/refman.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 import re
 import requests
+import shutil
 from typing import Iterable, List, Tuple
 
 from arxiv2bib import arxiv2bib
@@ -16,6 +17,7 @@ import bibtexparser
 import pandas as pd
 import pyperclip
 from tqdm import tqdm
+import typer
 
 from ._constants import (
     REFMAN_DIR,
@@ -34,14 +36,18 @@ from ._scihub import SciHub
 
 STATUS_HANDLER = None
 LOGGER = logging.getLogger(f"refman.{__name__}")
-LOGGER.setLevel(logging.INFO)
+LOGGER.setLevel(logging.DEBUG)
 SH = SciHub()
+
+
+APP = typer.Typer(help="RefMan - A Simple python-based reference manager.")
 
 
 def update_status(msg: str, level_attr: str = 'info'):
     global STATUS_HANDLER
     if not isinstance(STATUS_HANDLER, tqdm):
-        LOGGER.__getattr__(level_attr).__call__(msg)
+        # LOGGER.__getattr__(level_attr)
+        LOGGER.info(msg)
         return
     STATUS_HANDLER.set_postfix_str(msg)
 
@@ -51,6 +57,10 @@ def progress_with_status(it: Iterable):
     ncols = str(min(len(it), 20))
     barfmt = "{l_bar}{bar:" + ncols + "}{r_bar}{bar:-" + ncols + "b}"
     return (STATUS_HANDLER := tqdm(it, bar_format=barfmt))
+
+def reset_progress_status_handler():
+    global STATUS_HANDLER
+    STATUS_HANDLER = None
 
 
 @dataclasses.dataclass
@@ -89,6 +99,14 @@ class Paper:
         return meta.get("ID")
 
     @classmethod
+    def _update_bibtex_str_key(cls, bibtex_str: str, key: str):
+        bib = bibtexparser.loads(bibtex_str)
+        if not bib.entries[0].get("DOI", False):
+            bib.entries[0]["DOI"] = ""
+        bib.entries[0]["ID"] = key
+        return bibtexparser.dumps(bib)
+
+    @classmethod
     def parse_from_disk(cls, paper_path: Path, read_pdf: bool = False):
         """Returns a `Paper` object from disk."""
         update_status(f"{paper_path}: Loading reference from disk.")
@@ -108,10 +126,13 @@ class Paper:
         return cls(meta=meta, bibtex=bibtex, pdf_data=pdf_data)
 
     @classmethod
-    def new_paper_from_arxiv(cls, arxiv: str):
+    def new_paper_from_arxiv(cls, arxiv: str, key: str = None):
         """Adds a new paper to the `papers` dir from an arxiv str"""
         update_status(f"{arxiv=}: Retrieving bibtex entry.")
         bib_str = fix_arxiv2bib_fmt(arxiv2bib([arxiv])[0])
+        # Set custom key if requested
+        if key is not None:
+            bib_str = cls._update_bibtex_str_key(bib_str, key)
         meta = dict(bibtexparser.loads(bib_str).entries[0])
         update_status(f"{arxiv=}: Retrieving PDF.")
         pdf_data = requests.get(ARXIV_PDF_URL.format(arxiv=arxiv)).content
@@ -120,7 +141,7 @@ class Paper:
         return paper
 
     @classmethod
-    def new_paper_from_doi(cls, doi: str, pdf: str = None):
+    def new_paper_from_doi(cls, doi: str, key: str = None, pdf: str = None):
         """Adds a new paper to the `papers` dir from a DOI"""
         # Fetch the reference data from cross-ref
         if not is_valid_doi(doi):
@@ -143,6 +164,10 @@ class Paper:
             pdf_data = cls._get_pdf_data_from_path(pdf_path=pdf)
         if pdf_data is None:
             pdf_data = cls._get_pdf_data_from_doi(doi, citeproc_json)
+        # Set custom key if requested
+        if key is not None:
+            bib_str = cls._update_bibtex_str_key(bib_str, key)
+        # Prepare the Paper object
         meta = dict(bibtexparser.loads(bib_str).entries[0])
         paper = cls(meta=meta, bibtex=bib_str, pdf_data=pdf_data)
         paper.to_disk()
@@ -158,12 +183,10 @@ class Paper:
         """Adds a new paper to the `papers` dir from a bibtex_str.
         Optionally: Associate a pdf with the paper via local path or url
         """
-        bib = bibtexparser.loads(bibtex_str)
-        if not bib.entries[0].get("DOI", False):
-            bib.entries[0]["DOI"] = ""
+        # Set custom key if requested
         if key is not None:
-            bib.entries[0]["ID"] = key
-            bibtex_str = bibtexparser.dumps(bib)
+            bibtex_str = cls._update_bibtex_str_key(bibtex_str, key)
+        bib = bibtexparser.loads(bibtex_str)
         meta = dict(bib.entries[0])
         bibtex_key = cls._bibtex_key_from_bibtex_str(meta)
         LOGGER.info(f"{bibtex_key}: Parsing BibTeX string.")
@@ -246,11 +269,17 @@ class RefMan:
     db: pd.DataFrame = dataclasses.field(init=False, default=None)
 
     def __post_init__(self):
+        if not os.getenv("REFMAN_DATA", False):
+            LOGGER.warning(
+                f"`REFMAN_DATA` not found in environment variables. Using '{REFMAN_DIR}' as data path."
+            )
+        REFMAN_DIR.mkdir(exist_ok=True, parents=True)
         LOGGER.info("Parsing database.")
         paper_paths = self._paper_paths_list()
         if len(paper_paths) > 0:
             path_it = progress_with_status(paper_paths)
             papers = list(map(Paper.parse_from_disk, path_it))
+            reset_progress_status_handler()
             self.db = pd.DataFrame(map(self._get_paper_meta, papers))
         else:
             self.db = pd.DataFrame(None)
@@ -269,9 +298,12 @@ class RefMan:
     def append_to_db(self, paper: Paper):
         self.db = self.db.append(self._get_paper_meta(paper), ignore_index=True)
 
-    def add_using_arxiv(self, arxiv: str):
+    def remove_from_db(self, column: str, value: str):
+        self.db = self.db[self.db[column] != value]
+        
+    def add_using_arxiv(self, arxiv: str, key: str = None):
         if arxiv is not None and arxiv not in list(self.db.get("eprint", list())):
-            paper = Paper.new_paper_from_arxiv(arxiv)
+            paper = Paper.new_paper_from_arxiv(arxiv, key)
             self.append_to_db(paper)
 
         self._update_db()
@@ -306,6 +338,39 @@ class RefMan:
         self._update_db()
         return paper.meta.get("ID", "")
 
+    def rekey(self, key: str, new_key: str):
+        paper_path_li = list(REFMAN_DIR.glob(key + "*"))
+        if len(paper_path_li) > 1:
+            raise ValueError(f"Multiple papers matching wildcard: {key + '*'}.\n{paper_path_li=}.")
+        if len(paper_path_li) == 0:
+            raise FileNotFoundError(f"No papers matching wildcard: {key + '*'}. Exiting.")
+        paper_path = paper_path_li[0]
+        old_paper = Paper.parse_from_disk(paper_path)
+        new_paper = Paper.new_paper_from_bibtex(
+            bibtex_str=old_paper.bibtex,
+            pdf_path=old_paper.pdf_path,
+            key=new_key
+        )
+        # Remove the old paper
+        self.remove_paper(key)
+        return new_paper.meta.get("ID", "")
+
+    def remove_paper(self, key: str):
+        paper_path = REFMAN_DIR / key
+        if not paper_path.exists():
+            LOGGER.info(f"Couldn't find any paper at: {paper_path}. Trying wildcard...")
+            paper_path_li = list(REFMAN_DIR.glob(key + "*"))
+            if len(paper_path_li) > 1:
+                raise ValueError(f"Multiple papers matching wildcard: {key + '*'}.\n{paper_path_li=}.")
+            if len(paper_path_li) == 0:
+                raise FileNotFoundError(f"No papers matching wildcard: {key + '*'}. Exiting.")
+            paper_path = paper_path_li[0]
+                
+        LOGGER.info(f"Found paper: {paper_path}: Removing it and updating database.")
+        shutil.rmtree(paper_path)
+        self.remove_from_db(column="bibtex_path", value=str(paper_path / BIBTEX_NAME))
+        self._update_db()
+
     def _update_db(self):
         # Write out bibliography file
         LOGGER.info(f"Writing bibliography file to '{BIB_REF}'.")
@@ -314,87 +379,48 @@ class RefMan:
                 f.write(open(paper_bibtex, "r").read() + "\n")
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="RefMan - A Simple python-based reference manager."
-    )
-    parser.add_argument(
-        "-d",
-        "--doi",
-        help=(
-            "Tries to find and download the paper using the DOI. "
-        ),
-        type=str,
-        required=False,
-        default=None,
-    )
-    parser.add_argument(
-        "-a",
-        "--arxiv",
-        help=(
-            "Gets the paper from an Arxiv reference string. "
-        ),
-        type=str,
-        required=False,
-        default=None,
-    )
-    parser.add_argument(
-        "-b",
-        "--bibtex",
-        help=(
-            "Adds an entry to the database from a bibtex-string. "
-            "Optionally, provide -p, --pdf to associate this entry with a PDF."
-        ),
-        type=str,
-        default=None,
-    )
-    parser.add_argument(
-        "-p",
-        "--pdf",
-        help=(
-            "Adds an entry to the database from a bibtex-string. "
-            "Optionally, provide -p, --pdf to associate this entry with a PDF."
-        ),
-        type=str,
-        default=None,
-    )
-    parser.add_argument(
-        "-k",
-        "--key",
-        help=(
-            "Explicitly define the key to use (without hash) for the paper."
-        ),
-        type=str,
-        default=None,
-    )
-    args = parser.parse_args()
-    if bool(args.arxiv) and bool(args.pdf):
-        raise ValueError(
-            f"`-p, --pdf` cannot be used with `-a, --arxiv`."
-        )
-
-    if not os.getenv("REFMAN_DATA", False):
-        LOGGER.warning(
-            f"`REFMAN_DATA` not found in environment variables. Using '{REFMAN_DIR}' as data path."
-        )
-    REFMAN_DIR.mkdir(exist_ok=True, parents=True)
-
+@APP.command()
+def doi(doi: str, key: str = None, pdf: str = None):
+    """Gets the paper from an Arxiv reference string"""
+    typer.echo(f"Adding new paper from {doi=}")
     refman = RefMan()
-    new_citations = []
-    if bool(args.arxiv):
-        for job_kwargs in progress_with_status([{'arxiv': args.arxiv}]):
-            new_citations.append(refman.add_using_arxiv(**job_kwargs))
-    if bool(args.doi):
-        for job_kwargs in progress_with_status([{'doi': args.doi, 'pdf': args.pdf}]):
-            new_citations.append(refman.add_using_doi(**job_kwargs))
-    if bool(args.bibtex):
-        for job_kwargs in progress_with_status(
-                [{'bibtex_str': args.bibtex, 'pdf_path': args.pdf, 'key': args.key}]
-        ):
-            new_citations.append(refman.add_using_bibtex(**job_kwargs))
+    new_citation = refman.add_using_doi(doi=doi, key=key, pdf=pdf)
+    pyperclip.copy(f"\cite{{{new_citation}}}")
 
-    pyperclip.copy(f"\cite{','.join(new_citations)}")
+
+@APP.command()
+def arxiv(arxiv: str, key: str = None):
+    """Tries to find and download the paper using the DOI."""
+    typer.echo(f"Adding new paper from {arxiv=}")
+    refman = RefMan()
+    new_citation = refman.add_using_arxiv(arxiv=arxiv, key=key)
+    pyperclip.copy(f"\cite{{{new_citation}}}")
+
+
+@APP.command()
+def bibtex(bibtex: str, key: str = None, pdf: str = None):
+    """Adds an entry to the database from a bibtex-string."""
+    typer.echo(f"Adding new paper from bibtex.")
+    refman = RefMan()
+    new_citation = refman.add_using_bibtex(bibtex_str=bibtex, key=key, pdf_path=pdf)
+    pyperclip.copy(f"\cite{{{new_citation}}}")
+
+
+@APP.command()
+def rekey(key: str, new_key: str):
+    """Modify the key of a paper."""
+    refman = RefMan()
+    new_citation = refman.rekey(key=key, new_key=new_key)
+    pyperclip.copy(f"\cite{{{new_citation}}}")
+
+
+@APP.command()
+def rm(key: str):
+    """Removes a paper from the disk and database."""
+    typer.echo(f"Attempting to remove paper with key:")
+    refman = RefMan()
+    new_citation = refman.remove_paper(key=key)
 
 
 if __name__ == "__main__":
-    main()
+    APP()

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,10 @@ setup(
         "bs4",
         "numpy",
         "pandas",
+        "pyperclip",
         "retrying",
         "tqdm",
+        "typer",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = (HERE / "README.md").read_text()
 # This call to setup() does all the work
 setup(
     name="refman",
-    version="0.0.1",
+    version="0.0.2",
     description="RefMan - A Simple python-based reference manager",
     long_description=README,
     long_description_content_type="text/markdown",
@@ -38,7 +38,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "refman=refman.refman:main",
+            "refman=refman.refman:APP",
         ]
     },
 )


### PR DESCRIPTION
- Migrates from `argparse` to `typer`
- Adds `key` kwarg to `doi` and `arxiv` commands
- Add `rm` and `rekey` commands